### PR TITLE
[API] 나의 대시보드 리액트쿼리 커스텀 훅 생성 및 적용

### DIFF
--- a/src/api/dashboards.api.ts
+++ b/src/api/dashboards.api.ts
@@ -1,4 +1,3 @@
-
 import instance from './instance';
 import { API, API_DASHBOARDS } from '@/constants/API';
 
@@ -19,12 +18,14 @@ const postCreateDashboard = ({ title, color }) => {
 /**
  * 대시보드 목록조회 api
  */
-const getDashboardList = (navigationMethod: string) => {
+const getDashboardList = ({ navigationMethod, page, size }) => {
   return instance({
     url: API.DASHBOARDS,
     method: 'GET',
     params: {
       navigationMethod,
+      page,
+      size,
     },
   });
 };

--- a/src/api/invitations.api.ts
+++ b/src/api/invitations.api.ts
@@ -1,0 +1,44 @@
+import { API, API_INVITATIONS } from '@/constants/API';
+import instance from '@/api/instance';
+
+interface MyInvitationParams {
+  size: string;
+  cursorId: string;
+}
+
+interface InvitationResponseParams {
+  invitationId: string;
+  inviteAccepted: boolean;
+}
+
+/**
+ * 내가받은 초대목록 조회 api
+ */
+const getMyInvitationList = ({ size, cursorId }: MyInvitationParams) => {
+  return instance({
+    url: API.INVITATIONS,
+    method: 'GET',
+    params: {
+      size,
+      cursorId,
+    },
+  });
+};
+
+/**
+ * 초대 응답 api
+ */
+const putInvitationResponse = ({
+  invitationId,
+  inviteAccepted,
+}: InvitationResponseParams) => {
+  return instance({
+    url: API_INVITATIONS.BY_ID(invitationId),
+    method: 'PUT',
+    data: {
+      inviteAccepted,
+    },
+  });
+};
+
+export default { getMyInvitationList, putInvitationResponse };

--- a/src/api/invitations.api.ts
+++ b/src/api/invitations.api.ts
@@ -1,11 +1,6 @@
 import { API, API_INVITATIONS } from '@/constants/API';
 import instance from '@/api/instance';
 
-interface MyInvitationParams {
-  size: string;
-  cursorId: string;
-}
-
 interface InvitationResponseParams {
   invitationId: string;
   inviteAccepted: boolean;
@@ -14,13 +9,12 @@ interface InvitationResponseParams {
 /**
  * 내가받은 초대목록 조회 api
  */
-const getMyInvitationList = ({ size, cursorId }: MyInvitationParams) => {
+const getMyInvitationList = (size: string) => {
   return instance({
     url: API.INVITATIONS,
     method: 'GET',
     params: {
       size,
-      cursorId,
     },
   });
 };

--- a/src/components/dashboard/my-board/DashBoardList.tsx
+++ b/src/components/dashboard/my-board/DashBoardList.tsx
@@ -1,8 +1,10 @@
 import Link from 'next/link';
+import { useEffect, useState } from 'react';
 import { styled } from 'styled-components';
 import CircleColor from '@/components/common/CircleColor';
 import AddIconButton from '@/components/common/button/AddIconButton';
 import MEDIA_QUERIES from '@/constants/MEDIAQUERIES';
+import dashboardsApi from '@/api/dashboards.api';
 import CrownIcon from '@/public/icon/crownIcon.svg';
 import RightArrow from '@/public/icon/rightArraowIcon.svg';
 import { GridTemplate } from '@/styles/CommonStyle';
@@ -39,60 +41,30 @@ const S = {
   `,
 };
 
-const dashboards = [
-  {
-    id: 1,
-    title: '이게맞냐구',
-    color: '#76A5EA',
-    createdAt: '2024-04-21T14:07:17.165Z',
-    updatedAt: '2024-04-21T14:07:17.165Z',
-    createdByMe: true,
-    userId: 1,
-  },
-  {
-    id: 2,
-    title: '나는 괜찮아',
-    color: '#E876EA',
-    createdAt: '2024-04-21T14:07:17.165Z',
-    updatedAt: '2024-04-21T14:07:17.165Z',
-    createdByMe: false,
-    userId: 1,
-  },
-  {
-    id: 3,
-    title: '이게맞냐구',
-    color: '#76A5EA',
-    createdAt: '2024-04-21T14:07:17.165Z',
-    updatedAt: '2024-04-21T14:07:17.165Z',
-    createdByMe: true,
-    userId: 1,
-  },
-  {
-    id: 4,
-    title: '나는 괜찮아',
-    color: '#E876EA',
-    createdAt: '2024-04-21T14:07:17.165Z',
-    updatedAt: '2024-04-21T14:07:17.165Z',
-    createdByMe: false,
-    userId: 1,
-  },
-  {
-    id: 5,
-    title: '이게맞냐구',
-    color: '#76A5EA',
-    createdAt: '2024-04-21T14:07:17.165Z',
-    updatedAt: '2024-04-21T14:07:17.165Z',
-    createdByMe: true,
-    userId: 1,
-  },
-];
-
 function DashBoardList() {
+  const [dashboards, setDashboards] = useState([]);
+
+  useEffect(() => {
+    const fetchData = async () => {
+      try {
+        const response = await dashboardsApi.getDashboardList('infiniteScroll');
+        setDashboards(response.data); // 받은 데이터를 dashboards 상태로 설정
+      } catch (error) {
+        console.error('목록조회 오류:', error.response.data.message);
+      }
+    };
+
+    fetchData(); // 컴포넌트가 마운트되었을 때 데이터를 가져오도록 호출
+  }, []);
+
+  const boards = dashboards.dashboards;
+  console.log('대시보드 데이터: ', boards);
+
   return (
     <GridTemplate>
       <AddIconButton style={{ height: '7rem' }}>새로운 대시보드</AddIconButton>
-      {dashboards.map((board) => (
-        <S.Container>
+      {boards?.map((board) => (
+        <S.Container key={board.id}>
           <S.BoardTitle>
             <CircleColor color={board.color} />
             <div>
@@ -100,7 +72,7 @@ function DashBoardList() {
               {board.createdByMe && <CrownIcon className="crown" />}
             </div>
           </S.BoardTitle>
-          <Link href={`/my-dashboards/${board.id}`}>
+          <Link href={`/dashboard/${board.id}`}>
             <RightArrow />
           </Link>
         </S.Container>

--- a/src/components/dashboard/my-board/DashBoardList.tsx
+++ b/src/components/dashboard/my-board/DashBoardList.tsx
@@ -3,6 +3,7 @@ import { useEffect, useState } from 'react';
 import { styled } from 'styled-components';
 import CircleColor from '@/components/common/CircleColor';
 import AddIconButton from '@/components/common/button/AddIconButton';
+import useDashboardListQuery from '@/hooks/query/dashboards/useDashboardListQuery';
 import MEDIA_QUERIES from '@/constants/MEDIAQUERIES';
 import dashboardsApi from '@/api/dashboards.api';
 import CrownIcon from '@/public/icon/crownIcon.svg';
@@ -42,28 +43,17 @@ const S = {
 };
 
 function DashBoardList() {
-  const [dashboards, setDashboards] = useState([]);
-
-  useEffect(() => {
-    const fetchData = async () => {
-      try {
-        const response = await dashboardsApi.getDashboardList('infiniteScroll');
-        setDashboards(response.data); // 받은 데이터를 dashboards 상태로 설정
-      } catch (error) {
-        console.error('목록조회 오류:', error.response.data.message);
-      }
-    };
-
-    fetchData(); // 컴포넌트가 마운트되었을 때 데이터를 가져오도록 호출
-  }, []);
-
-  const boards = dashboards.dashboards;
-  console.log('대시보드 데이터: ', boards);
+  const { data } = useDashboardListQuery({
+    navigationMethod: 'pagination',
+    page: 1,
+    size: 5,
+  });
+  const dashboards = data?.dashboards;
 
   return (
     <GridTemplate>
       <AddIconButton style={{ height: '7rem' }}>새로운 대시보드</AddIconButton>
-      {boards?.map((board) => (
+      {dashboards?.map((board) => (
         <S.Container key={board.id}>
           <S.BoardTitle>
             <CircleColor color={board.color} />

--- a/src/components/dashboard/my-board/InvitedDashBoardList.tsx
+++ b/src/components/dashboard/my-board/InvitedDashBoardList.tsx
@@ -4,6 +4,7 @@ import { styled } from 'styled-components';
 import Button from '@/components/common/button/Button';
 import NoInvitation from '@/components/dashboard/my-board/NoInvitation';
 import SearchBar from '@/components/dashboard/my-board/SearchBar';
+import useMyInvitationListQuery from '@/hooks/query/dashboards/useMyInvitationListQuery';
 import { BUTTON_TYPE } from '@/constants/BUTTON_TYPE';
 import MEDIA_QUERIES from '@/constants/MEDIAQUERIES';
 
@@ -128,97 +129,12 @@ const S = {
   `,
 };
 
-const invitations = [
-  {
-    id: 1,
-    inviter: {
-      nickname: '공주',
-      email: 'test@test.com',
-      id: 1,
-    },
-    teamId: '1',
-    dashboard: {
-      title: '공주들 화이팅이다다',
-      id: 1,
-    },
-    invitee: {
-      nickname: '11팀',
-      email: 'test1@test.com',
-      id: 1,
-    },
-    inviteAccepted: false,
-    createdAt: '2024-04-21T12:08:17.124Z',
-    updatedAt: '2024-04-21T12:08:17.124Z',
-  },
-  {
-    id: 2,
-    inviter: {
-      nickname: '왕자',
-      email: 'test@test.com',
-      id: 2,
-    },
-    teamId: '1',
-    dashboard: {
-      title: '왕자도화이팅',
-      id: 1,
-    },
-    invitee: {
-      nickname: '11팀',
-      email: 'test1@test.com',
-      id: 1,
-    },
-    inviteAccepted: false,
-    createdAt: '2024-04-21T12:08:17.124Z',
-    updatedAt: '2024-04-21T12:08:17.124Z',
-  },
-  {
-    id: 3,
-    inviter: {
-      nickname: '퀸퀸아머퀸',
-      email: 'test@test.com',
-      id: 1,
-    },
-    teamId: '1',
-    dashboard: {
-      title: '퀸이될게',
-      id: 1,
-    },
-    invitee: {
-      nickname: '11팀',
-      email: 'test1@test.com',
-      id: 1,
-    },
-    inviteAccepted: false,
-    createdAt: '2024-04-21T12:08:17.124Z',
-    updatedAt: '2024-04-21T12:08:17.124Z',
-  },
-  {
-    id: 4,
-    inviter: {
-      nickname: '이게 무슨일이야',
-      email: 'test@test.com',
-      id: 3,
-    },
-    teamId: '1',
-    dashboard: {
-      title: '이제 어떻게 되려나',
-      id: 1,
-    },
-    invitee: {
-      nickname: '11팀',
-      email: 'test1@test.com',
-      id: 1,
-    },
-    inviteAccepted: false,
-    createdAt: '2024-04-21T12:08:17.124Z',
-    updatedAt: '2024-04-21T12:08:17.124Z',
-  },
-];
-
 function InvitedDashBoardList() {
   const searchParams = useSearchParams();
   const [keyword, setKeyword] = useState(searchParams.get('keyword'));
-  const isInvitation = false;
+
+  const { data } = useMyInvitationListQuery(10);
+  const invitations = data?.invitations;
 
   useEffect(() => {
     setKeyword(searchParams.get('keyword'));
@@ -227,7 +143,7 @@ function InvitedDashBoardList() {
   return (
     <S.Container>
       <S.Title>초대받은 대시보드</S.Title>
-      {!!isInvitation ? (
+      {!invitations ? (
         <NoInvitation />
       ) : (
         <>
@@ -245,7 +161,7 @@ function InvitedDashBoardList() {
             </S.InvitationTabBar>
 
             {invitations.map((invitation) => (
-              <S.Invitation>
+              <S.Invitation key={invitation.id}>
                 <S.TitleAndInviter>
                   <S.BoardTitle>{invitation.dashboard.title}</S.BoardTitle>
                   <S.Inviter>{invitation.inviter.nickname}</S.Inviter>

--- a/src/components/dashboard/my-board/InvitedDashBoardList.tsx
+++ b/src/components/dashboard/my-board/InvitedDashBoardList.tsx
@@ -4,6 +4,7 @@ import { styled } from 'styled-components';
 import Button from '@/components/common/button/Button';
 import NoInvitation from '@/components/dashboard/my-board/NoInvitation';
 import SearchBar from '@/components/dashboard/my-board/SearchBar';
+import useAcceptInvitationMutation from '@/hooks/query/dashboards/useAcceptInvitationMutation';
 import useMyInvitationListQuery from '@/hooks/query/dashboards/useMyInvitationListQuery';
 import { BUTTON_TYPE } from '@/constants/BUTTON_TYPE';
 import MEDIA_QUERIES from '@/constants/MEDIAQUERIES';
@@ -136,6 +137,25 @@ function InvitedDashBoardList() {
   const { data } = useMyInvitationListQuery(10);
   const invitations = data?.invitations;
 
+  const { mutate: responseInvitationMutate } = useAcceptInvitationMutation();
+
+  const handleAcceptButtonClick = (invitationId: string) => {
+    responseInvitationMutate({
+      invitationId: invitationId,
+      inviteAccepted: true,
+    });
+  };
+
+  const handleRejectButtonClick = (invitationId: string) => {
+    const confirmReject = window.confirm('정말 초대를 거절하시겠어요?🥹'); // 나중에 모달 대체로
+    if (confirmReject) {
+      responseInvitationMutate({
+        invitationId: invitationId,
+        inviteAccepted: false,
+      });
+    }
+  };
+
   useEffect(() => {
     setKeyword(searchParams.get('keyword'));
   }, [searchParams]);
@@ -167,8 +187,17 @@ function InvitedDashBoardList() {
                   <S.Inviter>{invitation.inviter.nickname}</S.Inviter>
                 </S.TitleAndInviter>
                 <S.ButtonContainer>
-                  <Button size="S">수락</Button>
-                  <Button size="S" styleType={BUTTON_TYPE.SECONDARY}>
+                  <Button
+                    size="S"
+                    onClick={() => handleAcceptButtonClick(invitation.id)}
+                  >
+                    수락
+                  </Button>
+                  <Button
+                    size="S"
+                    styleType={BUTTON_TYPE.SECONDARY}
+                    onClick={() => handleRejectButtonClick(invitation.id)}
+                  >
                     거절
                   </Button>
                 </S.ButtonContainer>

--- a/src/hooks/query/dashboards/useAcceptInvitationMutation.ts
+++ b/src/hooks/query/dashboards/useAcceptInvitationMutation.ts
@@ -1,0 +1,22 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { API } from '@/constants/API';
+import invitationsApi from '@/api/invitations.api';
+
+// 초대 응답
+function useAcceptInvitationMutation() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async ({ invitationId, inviteAccepted }) => {
+      return invitationsApi.putInvitationResponse({
+        invitationId,
+        inviteAccepted,
+      });
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries([API.INVITATIONS]);
+    },
+  });
+}
+
+export default useAcceptInvitationMutation;

--- a/src/hooks/query/dashboards/useDashboardListQuery.ts
+++ b/src/hooks/query/dashboards/useDashboardListQuery.ts
@@ -1,0 +1,21 @@
+import { useQuery } from '@tanstack/react-query';
+import { API } from '@/constants/API';
+import dashboardsApi from '@/api/dashboards.api';
+
+// 대시보드 목록조회
+function useDashboardListQuery({ navigationMethod, page, size }) {
+  return useQuery({
+    queryKey: [API.DASHBOARDS, navigationMethod],
+    queryFn: async () => {
+      const { data } = await dashboardsApi.getDashboardList({
+        navigationMethod,
+        page,
+        size,
+      });
+      return data;
+    },
+    // { Success or Error 처리 등의 옵션자리 }
+  });
+}
+
+export default useDashboardListQuery;

--- a/src/hooks/query/dashboards/useMyInvitationListQuery.ts
+++ b/src/hooks/query/dashboards/useMyInvitationListQuery.ts
@@ -1,16 +1,21 @@
-import { useQuery } from '@tanstack/react-query';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { API } from '@/constants/API';
 import invitationsApi from '@/api/invitations.api';
 
 // 내가 받은 초대목록
 function useMyInvitationListQuery(size: string) {
+  const queryClient = useQueryClient();
+
   return useQuery({
     queryKey: [API.INVITATIONS],
     queryFn: async () => {
       const { data } = await invitationsApi.getMyInvitationList(size);
       return data;
     },
-    // { Success or Error 처리 등의 옵션자리 }
+    onSuccess: () => {
+      // 쿼리 무효화
+      queryClient.invalidateQueries([API.INVITATIONS]);
+    },
   });
 }
 

--- a/src/hooks/query/dashboards/useMyInvitationListQuery.ts
+++ b/src/hooks/query/dashboards/useMyInvitationListQuery.ts
@@ -1,0 +1,17 @@
+import { useQuery } from '@tanstack/react-query';
+import { API } from '@/constants/API';
+import invitationsApi from '@/api/invitations.api';
+
+// 내가 받은 초대목록
+function useMyInvitationListQuery(size: string) {
+  return useQuery({
+    queryKey: [API.INVITATIONS],
+    queryFn: async () => {
+      const { data } = await invitationsApi.getMyInvitationList(size);
+      return data;
+    },
+    // { Success or Error 처리 등의 옵션자리 }
+  });
+}
+
+export default useMyInvitationListQuery;

--- a/src/pages/my-dashboard.tsx
+++ b/src/pages/my-dashboard.tsx
@@ -21,7 +21,7 @@ const S = {
 
 function mydashboard() {
   return (
-    <PageLayout>
+    <PageLayout myPage={false}>
       <S.Container>
         <S.InnerWrap>
           <DashBoardList />


### PR DESCRIPTION
## 📌 주요 사항
- 나의 대시보드 페이지(레이아웃 no) api 연동 전부 완료했습니다.
- 아직 리액트 쿼리 디렉토리구조를 잡지 못해서 일단 하나의 커스텀 파일로 두었습니다.!
- 아직 타입정의들이 이루어지지 않은 상태입니다. 

## 📷 스크린샷

![5516150C-FF44-4E8F-BCA7-CC66B2841393_1_105_c](https://github.com/sprint-part3-team11/taskify/assets/124874266/541d68ea-5737-49db-83b9-0884ebffb397)

[ 이건 제가 설정한 데이터 5개로 한정해서 가져오기]  
![0F395A99-6D7F-4FF6-B2BE-48AD6ABCB97F](https://github.com/sprint-part3-team11/taskify/assets/124874266/a35d0bef-4bed-4893-80f9-0c2c7483ea97)

[ 이건 지윤님이 사이드바에 걸어놓은 api로직이 같이 동작해서 지윤님이 설정한 30개가 들어오고있는겁니다!]
![ABED2FAA-2EF7-49A8-8D08-3A29C0C20B08](https://github.com/sprint-part3-team11/taskify/assets/124874266/90909c20-1d5b-4a31-a1a7-e3955a1aaca4)

![my-dashboards](https://github.com/sprint-part3-team11/taskify/assets/124874266/f32a310f-0f5c-4dcb-a821-7fe8cf7f8f3e)



## 💬 리뷰 시 요구사항![선택]
useQuery만 올라간상태입니다! useMutation도 금방 푸시할게요!
+++ Mutation으로 put요청하는것도 올라갔습니다~



## #️⃣ 연관 이슈번호
close #77 
