### PR TITLE
[API] 비밀번호 변경 api 연결 성공 

### DIFF
--- a/src/components/common/ImgFileUpload.tsx
+++ b/src/components/common/ImgFileUpload.tsx
@@ -1,4 +1,4 @@
-import React, { useRef } from 'react';
+import React, { useEffect, useRef } from 'react';
 import {
   atom,
   useRecoilState,
@@ -7,7 +7,10 @@ import {
 } from 'recoil';
 import styled from 'styled-components';
 import { profileImageUrlState } from '@/hooks/query/users/useMyPropfileQuery';
-import { resultServerImgState } from '@/hooks/query/users/useProfileImgUploadMutation';
+import {
+  resultServerImgState,
+  useProfileImgUploadMutation,
+} from '@/hooks/query/users/useProfileImgUploadMutation';
 import MEDIA_QUERIES from '@/constants/MEDIAQUERIES';
 import AddIcon from '@/public/icon/addImgIcon.svg';
 import EditIcon from '@/public/icon/editPencilIcon.svg';
@@ -114,10 +117,20 @@ interface ImgFileUploadProps {
 }
 
 function ImgFileUpload({ edit, small }: ImgFileUploadProps): JSX.Element {
-  const setUploadedImage = useSetRecoilState(imgUrlState);
-  const imgServerUrl = useRecoilValue<string>(resultServerImgState);
   const fileInputRef = useRef<HTMLInputElement>(null);
+  // File 객체 데이터
+  const [uploadedImage, setUploadedImage] = useRecoilState(imgUrlState);
+  // 내가 선택한 사진 url
+  const imgServerUrl = useRecoilValue<string>(resultServerImgState);
+  // 내 프로필 사진 (서버한테 받은)url <마이페이지에서만 사용>
   const profileImageUrl = useRecoilValue(profileImageUrlState);
+
+  const { mutate: profileImg } = useProfileImgUploadMutation();
+  useEffect(() => {
+    if (uploadedImage) {
+      profileImg(uploadedImage);
+    }
+  }, [uploadedImage]);
 
   const handleClick: () => void = () => {
     if (fileInputRef.current) {
@@ -151,8 +164,15 @@ function ImgFileUpload({ edit, small }: ImgFileUploadProps): JSX.Element {
             </S.Overlay>
           )}
         </>
-      ) : small ? (
-        <div>이미지를 추가해주세요.</div>
+      ) : small && imgServerUrl ? (
+        <>
+          <S.Image src={imgServerUrl} alt="업로드된 이미지" $small={small} />
+          {edit && (
+            <S.Overlay $small={small}>
+              <EditIcon />
+            </S.Overlay>
+          )}
+        </>
       ) : (
         <S.AddIcon onClick={handleClick} $small={small}>
           <AddIcon />

--- a/src/components/common/ImgFileUpload.tsx
+++ b/src/components/common/ImgFileUpload.tsx
@@ -1,6 +1,13 @@
 import React, { useRef } from 'react';
-import { atom, useRecoilState } from 'recoil';
+import {
+  atom,
+  useRecoilState,
+  useRecoilValue,
+  useSetRecoilState,
+} from 'recoil';
 import styled from 'styled-components';
+import { profileImageUrlState } from '@/hooks/query/users/useMyPropfileQuery';
+import { resultServerImgState } from '@/hooks/query/users/useProfileImgUploadMutation';
 import MEDIA_QUERIES from '@/constants/MEDIAQUERIES';
 import AddIcon from '@/public/icon/addImgIcon.svg';
 import EditIcon from '@/public/icon/editPencilIcon.svg';
@@ -107,8 +114,10 @@ interface ImgFileUploadProps {
 }
 
 function ImgFileUpload({ edit, small }: ImgFileUploadProps): JSX.Element {
-  const [uploadedImage, setUploadedImage] = useRecoilState(imgUrlState);
+  const setUploadedImage = useSetRecoilState(imgUrlState);
+  const imgServerUrl = useRecoilValue<string>(resultServerImgState);
   const fileInputRef = useRef<HTMLInputElement>(null);
+  const profileImageUrl = useRecoilValue(profileImageUrlState);
 
   const handleClick: () => void = () => {
     if (fileInputRef.current) {
@@ -128,10 +137,11 @@ function ImgFileUpload({ edit, small }: ImgFileUploadProps): JSX.Element {
 
   return (
     <S.Label htmlFor="fileInput" $small={small}>
-      {uploadedImage ? (
+      {/* eslint-disable-next-line no-nested-ternary */}
+      {!small && (imgServerUrl || profileImageUrl) ? (
         <>
           <S.Image
-            src={URL.createObjectURL(uploadedImage)}
+            src={imgServerUrl || profileImageUrl}
             alt="업로드된 이미지"
             $small={small}
           />
@@ -141,6 +151,8 @@ function ImgFileUpload({ edit, small }: ImgFileUploadProps): JSX.Element {
             </S.Overlay>
           )}
         </>
+      ) : small ? (
+        <div>이미지를 추가해주세요.</div>
       ) : (
         <S.AddIcon onClick={handleClick} $small={small}>
           <AddIcon />

--- a/src/components/landing/LandingHeader.tsx
+++ b/src/components/landing/LandingHeader.tsx
@@ -119,7 +119,7 @@ export default function LandingHeader() {
   const router = useRouter();
 
   const handleLoginClick = () => {
-    router.push('/login');
+    router.push('/signin');
   };
   return (
     <S.MainBox>

--- a/src/components/my-page/PasswordChange.tsx
+++ b/src/components/my-page/PasswordChange.tsx
@@ -1,5 +1,6 @@
 import styled from 'styled-components';
 import FormInput from '@/components/common/form/Form';
+import usePasswordChangeMutation from '@/hooks/query/auth/usePasswordChangeMutation';
 import MEDIA_QUERIES from '@/constants/MEDIAQUERIES';
 import authApi from '@/api/auth.api';
 
@@ -34,26 +35,36 @@ const S = {
 
 function PasswordChange() {
   // editMyProfilePassword FormInput에 props로 함수 보내기
-  const editMyProfilePassword = async (
-    editPassword: string,
-    newEditPassword: string,
-  ) => {
-    try {
-      const response = await authApi.getPasswordChange({
-        password: editPassword,
-        newPassword: newEditPassword,
-      });
-      console.log(response.data);
-    } catch (error) {
-      console.error('에러:', error.response.data.message);
-    }
+  // const editMyProfilePassword = async (
+  //   editPassword: string,
+  //   newEditPassword: string,
+  // ) => {
+  //   try {
+  //     const response = await authApi.getPasswordChange({
+  //       password: editPassword,
+  //       newPassword: newEditPassword,
+  //     });
+  //     console.log(response.data);
+  //   } catch (error) {
+  //     console.error('에러:', error.response.data.message);
+  //   }
+  // };
+
+  const { mutate: passwordChange } = usePasswordChangeMutation();
+
+  const editMyPassword = (data) => {
+    passwordChange(data);
   };
   return (
     <S.Layout>
       <S.Container>
         <S.Title>비밀번호 변경</S.Title>
         <S.PasswordContent>
-          <FormInput formType="editPassword" btnSize="S" />
+          <FormInput
+            onSubmit={editMyPassword}
+            formType="editPassword"
+            btnSize="S"
+          />
         </S.PasswordContent>
       </S.Container>
     </S.Layout>

--- a/src/components/my-page/PasswordChange.tsx
+++ b/src/components/my-page/PasswordChange.tsx
@@ -1,8 +1,8 @@
 import styled from 'styled-components';
 import FormInput from '@/components/common/form/Form';
+import WarningModal from '@/components/common/modal/WarningModal';
 import usePasswordChangeMutation from '@/hooks/query/auth/usePasswordChangeMutation';
 import MEDIA_QUERIES from '@/constants/MEDIAQUERIES';
-import authApi from '@/api/auth.api';
 
 const S = {
   Layout: styled.div`
@@ -34,27 +34,16 @@ const S = {
 };
 
 function PasswordChange() {
-  // editMyProfilePassword FormInput에 props로 함수 보내기
-  // const editMyProfilePassword = async (
-  //   editPassword: string,
-  //   newEditPassword: string,
-  // ) => {
-  //   try {
-  //     const response = await authApi.getPasswordChange({
-  //       password: editPassword,
-  //       newPassword: newEditPassword,
-  //     });
-  //     console.log(response.data);
-  //   } catch (error) {
-  //     console.error('에러:', error.response.data.message);
-  //   }
-  // };
-
-  const { mutate: passwordChange } = usePasswordChangeMutation();
-
+  const {
+    mutate: passwordChange,
+    open,
+    setOpen,
+    modalMessage,
+  } = usePasswordChangeMutation();
   const editMyPassword = (data) => {
     passwordChange(data);
   };
+
   return (
     <S.Layout>
       <S.Container>
@@ -66,6 +55,11 @@ function PasswordChange() {
             btnSize="S"
           />
         </S.PasswordContent>
+        <WarningModal
+          isOpen={open}
+          onClose={() => setOpen(false)}
+          message={modalMessage}
+        />
       </S.Container>
     </S.Layout>
   );

--- a/src/components/my-page/ProfileChange.tsx
+++ b/src/components/my-page/ProfileChange.tsx
@@ -60,7 +60,6 @@ const S = {
 };
 
 function ProfileChange() {
-  const uploadedImage = useRecoilValue(imgUrlState);
   const imgServerUrl = useRecoilValue<string>(resultServerImgState);
   const setProfileImageUrl = useSetRecoilState(profileImageUrlState);
 
@@ -80,13 +79,6 @@ function ProfileChange() {
       }));
     }
   }, [myProfile]);
-
-  const { mutate: profileImg } = useProfileImgUploadMutation();
-  useEffect(() => {
-    if (uploadedImage) {
-      profileImg(uploadedImage);
-    }
-  }, [uploadedImage]);
 
   const { mutate: editProfile } = useProfileEditMutation(imgServerUrl);
   const editMyProfile = (data, imgServerUrl) => {

--- a/src/components/my-page/ProfileChange.tsx
+++ b/src/components/my-page/ProfileChange.tsx
@@ -1,9 +1,12 @@
 import { useEffect, useState } from 'react';
-import { useRecoilValue } from 'recoil';
+import { useRecoilValue, useSetRecoilState } from 'recoil';
 import styled from 'styled-components';
 import { ImgFileUpload, imgUrlState } from '@/components/common/ImgFileUpload';
 import FormInput from '@/components/common/form/Form';
-import useMyPropfileQuery from '@/hooks/query/users/useMyPropfileQuery';
+import {
+  profileImageUrlState,
+  useMyPropfileQuery,
+} from '@/hooks/query/users/useMyPropfileQuery';
 import useProfileEditMutation from '@/hooks/query/users/useMyprofileEditMutation';
 import {
   resultServerImgState,
@@ -57,15 +60,17 @@ const S = {
 };
 
 function ProfileChange() {
-  const urlImg = useRecoilValue(imgUrlState);
+  const uploadedImage = useRecoilValue(imgUrlState);
   const imgServerUrl = useRecoilValue<string>(resultServerImgState);
-  // profileInfo FormInput에 props로 객체 보내기
+  const setProfileImageUrl = useSetRecoilState(profileImageUrlState);
+
   const [profileInfo, setProfile] = useState({
     name: '',
     mail: '',
   });
 
   const { data: myProfile } = useMyPropfileQuery();
+  setProfileImageUrl(myProfile && myProfile.profileImageUrl);
   useEffect(() => {
     if (myProfile && myProfile.nickname && myProfile.email) {
       setProfile((prevProfile) => ({
@@ -78,14 +83,12 @@ function ProfileChange() {
 
   const { mutate: profileImg } = useProfileImgUploadMutation();
   useEffect(() => {
-    if (urlImg) {
-      profileImg(urlImg);
+    if (uploadedImage) {
+      profileImg(uploadedImage);
     }
-  }, [urlImg]);
+  }, [uploadedImage]);
 
-  // editMyProfile FormInput에 props로 함수 보내기
   const { mutate: editProfile } = useProfileEditMutation(imgServerUrl);
-
   const editMyProfile = (data, imgServerUrl) => {
     editProfile(data, imgServerUrl);
   };

--- a/src/hooks/query/auth/usePasswordChangeMutation.ts
+++ b/src/hooks/query/auth/usePasswordChangeMutation.ts
@@ -1,0 +1,19 @@
+import { useMutation } from '@tanstack/react-query';
+import authApi from '@/api/auth.api';
+
+// 프로필 수정 => 이미지, 닉네임
+function usePasswordChangeMutation() {
+  return useMutation({
+    mutationFn: async (data) => {
+      return authApi.getPasswordChange({
+        password: data.nowPassword,
+        newPassword: data.newPassword,
+      });
+    },
+    onSuccess: () => {
+      alert('비밀번호 변경 성공');
+    },
+  });
+}
+
+export default usePasswordChangeMutation;

--- a/src/hooks/query/auth/usePasswordChangeMutation.ts
+++ b/src/hooks/query/auth/usePasswordChangeMutation.ts
@@ -1,9 +1,12 @@
+import { useState } from 'react';
 import { useMutation } from '@tanstack/react-query';
 import authApi from '@/api/auth.api';
 
 // 프로필 수정 => 이미지, 닉네임
 function usePasswordChangeMutation() {
-  return useMutation({
+  const [open, setOpen] = useState(false);
+  const [modalMessage, setModalMessage] = useState('');
+  const mutation = useMutation({
     mutationFn: async (data) => {
       return authApi.getPasswordChange({
         password: data.nowPassword,
@@ -13,7 +16,19 @@ function usePasswordChangeMutation() {
     onSuccess: () => {
       alert('비밀번호 변경 성공');
     },
+    onError: (error) => {
+      setOpen(true);
+      const message = error.response?.data?.message || '오류가 발생했습니다.';
+      setModalMessage(message);
+    },
   });
+
+  return {
+    ...mutation,
+    open,
+    setOpen,
+    modalMessage,
+  };
 }
 
 export default usePasswordChangeMutation;

--- a/src/hooks/query/users/useMyPropfileQuery.ts
+++ b/src/hooks/query/users/useMyPropfileQuery.ts
@@ -1,6 +1,12 @@
 import { useQuery } from '@tanstack/react-query';
+import { atom, useRecoilValue, useSetRecoilState } from 'recoil';
 import { API } from '@/constants/API';
 import usersApi from '@/api/users.api';
+
+const profileImageUrlState = atom({
+  key: 'profileImageUrl', // 고유 키
+  default: '', // 기본값
+});
 
 // 대시보드 목록조회
 function useMyPropfileQuery() {
@@ -13,4 +19,4 @@ function useMyPropfileQuery() {
   });
 }
 
-export default useMyPropfileQuery;
+export { useMyPropfileQuery, profileImageUrlState };


### PR DESCRIPTION
## 📌 주요 사항
- 비밀번호 변경 api 연결 리액트 쿼리로 성공
- 랜딩 페이지 로그인 버튼 클릭 시 경로 변경
- 현재 비밀번호 틀릴 시 모달 띄우기
- 새로고침 해도 유저의 이미지로 마아페이지 화면 렌더링

## 📷 스크린샷
<img width="668" alt="스크린샷 2024-04-25 오후 8 28 53" src="https://github.com/sprint-part3-team11/taskify/assets/114905530/790fbcd1-a8d9-4ef9-b193-6669834a9bed">

## 💬 리뷰 시 요구사항![선택]
특별히 봐줬으면 하는 부분이 있다면 작성해주세요! 없다면 pass~



## #️⃣ 연관 이슈번호
이슈를 해결한 경우 👉🏻 close #117 
